### PR TITLE
README: Cut out generated bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,7 @@ This very small Ember Addon allows you to place configuration in your `environme
 
 ## Usage in your app
 
-- add it to your `package.json`: `"ember-cli-opbeat": "*"`
+- Add it to your `package.json`: `"ember-cli-opbeat": "*"`
 - `ember g ember-cli-opbeat`
 - Configure your application's ENV.APP section in  `environment.js`: add `opbeat: { appId: 'your-app-id', orgId: 'your-org-id' }`
 
-## Installation for developing
-
-* `git clone <repository-url>` this repository
-* `cd ember-cli-opbeat`
-* `npm install`
-* `bower install`
-
-## Running
-
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
-
-## Running Tests
-
-* `npm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
-
-## Building
-
-* `ember build`
-
-For more information on using ember-cli, visit [http://ember-cli.com/](http://ember-cli.com/).


### PR DESCRIPTION
This PR removes the generated bits of the README document.

Those bits aren't really helping us.