### PR TITLE
ember-cli-jshint updated to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-jshint": "^1.0.4",
+    "ember-cli-jshint": "2.0.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",


### PR DESCRIPTION
Update ember-cli-jshint to latest, to keep up. https://github.com/ember-cli/ember-cli-jshint/pull/22

Perhaps this is incompatible with ember-welcome-page, which keeps ember-cli-jshint on 1.x. 

See also: https://github.com/ember-cli/ember-welcome-page/pull/66